### PR TITLE
set bash's IFS to " "

### DIFF
--- a/v
+++ b/v
@@ -23,6 +23,7 @@ set -- $fnd
     exit
 }
 
+IFS=" " # only split on spaces as register lines may start  with ‘>’
 while read line; do
     [ "${line:0:1}" = ">" ] || continue
     fl=${line:2}


### PR DESCRIPTION
i got errors when using v because I had register lines starting with ‘>’ in my ~/.viminfo file. by just splitting on space characters this can be avoided since register contents are indented with a tab character.
