### PR TITLE
Allow vim and viminfo to be set a runtime

### DIFF
--- a/v
+++ b/v
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-vim=vim
-viminfo=~/.viminfo
+[ $vim ] || vim=vim
+[ $viminfo ] || viminfo=~/.viminfo
 
 usage="$(basename $0) [-a] [-l] [-[0-9]] [--debug] [--help] [regexes]"
 


### PR DESCRIPTION
Besides supporting a config file, testing for `$vim` and `$viminfo` allows you to do something like this:

```
$ vim=gvim viminfo=$XDG_CACHE_HOME/vim/viminfo v dslr
```

This also allows the user to set up different scenarios using aliases.
