### PR TITLE
Enable $vim in v to use a shell function

### DIFF
--- a/v
+++ b/v
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-[ $vim ] || vim=vim
+[ "$vim" ] || vim=vim
 [ $viminfo ] || viminfo=~/.viminfo
 
 usage="$(basename $0) [-a] [-l] [-[0-9]] [--debug] [--help] [regexes]"
@@ -51,4 +51,4 @@ elif [ "$i" ]; then
 fi
 
 [ "$resp" ] || exit
-"$vim" "${resp/\~/$HOME}"
+$vim "${resp/\~/$HOME}"


### PR DESCRIPTION
I have in my .bashrc the following function definition for vim.

``` bash
function vim {
  vim_orig=$(which 2>/dev/null vim)
  $vim_orig --serverlist | grep -q FOO
  # if server is running
  if [ $? -eq 0 ]; then
      $vim_orig --servername FOO --remote-silent "$@"
  else
      $vim_orig "$@" --servername FOO
  fi
}
```

This enables me to use the remote vim feature in a non-gui vim using an xterm like gnome terminal.
v does not inherit the alias and function definitions because of this in .bashrc (as it should be)
`[ -z "$PS1" ] && return`

So I'm using the following alias:
`alias v='vim="eval $(type vim  | tail -n +2); vim" v'`
to force v to use my function definition.

This pull request (my first one, I might have screwed something, but I hope not) changes the quoting of the $vim variable in v to enable this behaviour.
