### PR TITLE
Fix i variable

### DIFF
--- a/v
+++ b/v
@@ -24,6 +24,7 @@ set -- "${fnd[@]}"
     exit
 }
 
+i=
 while IFS=" " read line; do
     [ "${line:0:1}" = ">" ] || continue
     fl=${line:2}

--- a/v
+++ b/v
@@ -41,7 +41,7 @@ if [ "$edit" ]; then
     resp=${files[$((edit+1))]}
 elif [ "$i" = 1 -o "$list" = "" ]; then
     resp=${files[1]}
-elif [ "$i" ]; then 
+elif [ "$i" ]; then
     while [ $i -gt 0 ]; do
          echo -e "$((i-1))\t${files[$i]}"
          i=$((i-1))


### PR DESCRIPTION
Please merge this fix. Because you don't initialize i variable, script broke, if user have it defined as string (path for example).

Test broken behaviour which pull request fixes:
`export i=/tmp/; ./v`
`./v: line 36: /tmp/: syntax error: operand expected (error token is "/tmp/")`
`./v: line 43: [: /tmp/: integer expression expected`